### PR TITLE
fix: propagate debug names from parent locals to child upvalues

### DIFF
--- a/ast/src/local.rs
+++ b/ast/src/local.rs
@@ -71,6 +71,14 @@ impl RcLocal {
     pub fn name(&self) -> Option<String> {
         self.0 .0.lock().0.clone()
     }
+
+    /// Set the name of this local, but only if it doesn't already have one
+    pub fn set_name_if_unnamed(&self, name: Option<String>) {
+        let mut lock = self.0 .0.lock();
+        if lock.0.is_none() {
+            lock.0 = name;
+        }
+    }
 }
 
 impl LocalRw for RcLocal {

--- a/luau-lifter/src/lib.rs
+++ b/luau-lifter/src/lib.rs
@@ -283,6 +283,10 @@ fn link_upvalues(
                             ast::Upvalue::Copy(l) | ast::Upvalue::Ref(l) => l,
                         }))
                 {
+                    // Propagate debug name from parent local to child upvalue if unnamed
+                    if let Some(name) = old.name() {
+                        new.set_name_if_unnamed(Some(name));
+                    }
                     // println!("{} -> {}", old, new);
                     local_map.insert(old.clone(), new.clone());
                 }


### PR DESCRIPTION
## Summary

When a local in a parent function is captured as an upvalue by a child closure, the child's upvalue may not have a debug name in the bytecode even if the parent's local does. This fix propagates the debug name from the parent local to the child upvalue during upvalue linking.

## Changes

- Added `set_name_if_unnamed()` method to `RcLocal` for safely setting names on unnamed locals
- Modified `link_upvalues()` to propagate debug names from parent locals to child upvalues

## Before

Variables captured as upvalues would get synthetic names like `v_u_3_` even when the parent function had the original debug name:

```lua
-- Local values: currentIndex, numElements
function ConfigurationManager:configurationKeyIterator()
    return function()
        -- upvalues: (ref) v_u_3_, (copy) numElements, (copy) self
        if numElements <= v_u_3_ then
            return nil
        end
        v_u_3_ = v_u_3_ + 1
```

## After

Upvalues inherit the debug name from the parent local:

```lua
-- Local values: currentIndex, numElements
function ConfigurationManager:configurationKeyIterator()
    return function()
        -- upvalues: (ref) currentIndex, (copy) numElements, (copy) self
        if numElements <= currentIndex then
            return nil
        end
        currentIndex = currentIndex + 1
```

## Testing

Tested on FS25 dataS scripts - reduced `v_u_` occurrences from 79 across 12 files to 0.