### PR TITLE
Ignore binary assigns when inlining

### DIFF
--- a/ast/src/inline_temporaries.rs
+++ b/ast/src/inline_temporaries.rs
@@ -936,6 +936,10 @@ impl Inliner {
             return None;
         };
 
+        if let RValue::Binary(_) = &assign.right[0] {
+            return None;
+        };
+
         // We only check that a name exists, the filtering based on whether
         // it's unnamed or side-effect-free is done in find_inline_candidates
         local.name()?;


### PR DESCRIPTION
This fixes a case where binary operations as RHS values (e.g. `var + 1` or `str .. "text"`) would sometimes get incorrectly simplified or even outright removed during the optimization of temporaries. The result of these inaccuracies would be a lack of abstraction on certain statements (WRT the supposed source code), references to variables that don't appear to exist, variables that appear to be unused, or empty blocks entirely in the worst case - most of which would then result in missing logic in the resulting Lua code or a decrease in readability in the best case.

I've generated a diff for A/B comparison on `dataS\scripts` (game version `1.16.0.2 b37950`) to confirm the effectiveness of this change, which can be viewed here: https://cdn.taembo.net/diff.patch. In my opinion, this change brings a net positive in Lua code accuracy.

Relevant to #15 