### PR TITLE
Fix decompilation: gotos, variable naming, iterator inlining

### DIFF
--- a/ast/src/inline_temporaries.rs
+++ b/ast/src/inline_temporaries.rs
@@ -119,8 +119,13 @@ impl Inliner {
                 }
             }
 
-            // Note: we DON'T clear immediate_inlines or deferred_inlines here anymore -
-            // they persist until applied to a later statement in this block.
+            // Invalidate deferred inlines that could be stale due to side effects.
+            // Only function/method calls can mutate tables through side effects.
+            // Only Length (#t) operations are invalidated, not Index (t[k]) reads,
+            // because calls rarely affect specific field values of unrelated tables.
+            if block[i].has_side_effects() {
+                self.invalidate_stale_deferred_inlines(&block[i]);
+            }
 
             // Before recursing, apply any pending deferred inlines to the nested block(s).
             // This allows side-effect-free values from the parent scope to be inlined into
@@ -231,12 +236,12 @@ impl Inliner {
                             | RValue::Select(Select::MethodCall(_))
                     );
                 if is_iterator_call && assign.left.len() >= 1 {
-                    // Collect the local names being assigned
+                    // Collect the RcLocal objects being assigned (for identity matching)
                     let locals: Vec<_> = assign
                         .left
                         .iter()
                         .filter_map(|lv| lv.as_local())
-                        .filter_map(|l| l.name())
+                        .cloned()
                         .collect();
                     if locals.len() == assign.left.len() {
                         (true, locals)
@@ -262,9 +267,12 @@ impl Inliner {
                     // Check if this for-loop uses exactly our assigned locals
                     if generic_for.right.len() == assign_locals.len() {
                         let matches = generic_for.right.iter().zip(&assign_locals).all(
-                            |(rv, expected_name)| {
+                            |(rv, assign_local)| {
                                 if let RValue::Local(for_local) = rv {
-                                    for_local.name().as_ref() == Some(expected_name)
+                                    // Match by identity or by name (for SSA versions)
+                                    for_local == assign_local
+                                        || (for_local.name().is_some()
+                                            && for_local.name() == assign_local.name())
                                 } else {
                                     false
                                 }
@@ -280,9 +288,11 @@ impl Inliner {
                 // Only allow simple local assignments that don't reference our iterator locals
                 if let Statement::Assign(intervening) = &block[j] {
                     let reads_our_locals = intervening.right.iter().any(|rv| {
-                        rv.values_read()
-                            .iter()
-                            .any(|l| assign_locals.iter().any(|n| l.name().as_ref() == Some(n)))
+                        rv.values_read().iter().any(|l| {
+                            assign_locals.iter().any(|al| {
+                                *l == al || (l.name().is_some() && l.name() == al.name())
+                            })
+                        })
                     });
                     if reads_our_locals {
                         break; // Can't move past this
@@ -339,29 +349,13 @@ impl Inliner {
                         && assign.left.len() >= 1
                         && generic_for.right.len() == assign.left.len()
                     {
-                        // Check that all for-loop iterators are locals matching the assignment
-                        let mut matches = true;
-                        for (j, rv) in generic_for.right.iter().enumerate() {
-                            if let RValue::Local(for_local) = rv {
-                                if let LValue::Local(assign_local) = &assign.left[j] {
-                                    // Compare by identity OR by name for SSA versions
-                                    let same = for_local == assign_local
-                                        || (for_local.name().is_some()
-                                            && for_local.name() == assign_local.name());
-                                    if !same {
-                                        matches = false;
-                                        break;
-                                    }
-                                } else {
-                                    matches = false;
-                                    break;
-                                }
-                            } else {
-                                matches = false;
-                                break;
-                            }
-                        }
-                        matches
+                        // Check that all for-loop iterators are locals (not other RValues).
+                        // We don't require name matching because SSA destruction can leave
+                        // the assignment LHS and for-loop iterator locals in different
+                        // congruence classes with different names. The adjacency of a
+                        // call-assignment and GenericFor with matching arity is sufficient
+                        // to identify this as the decomposed GenericForInit pattern.
+                        generic_for.right.iter().all(|rv| matches!(rv, RValue::Local(_)))
                     } else {
                         false
                     }
@@ -1249,6 +1243,24 @@ impl Inliner {
                 }
             }
             _ => {}
+        }
+    }
+
+    /// Invalidate deferred inlines containing Length (#t) operations when a
+    /// function/method call is encountered. Calls can mutate tables (e.g.,
+    /// table.insert), making deferred #t expressions stale.
+    ///
+    /// Index operations (t[k]) are NOT invalidated because calls rarely modify
+    /// specific field values of unrelated tables, and doing so causes many
+    /// false positives (e.g., `pixel[2]` dropped due to `math.deg()` call).
+    fn invalidate_stale_deferred_inlines(&mut self, statement: &Statement) {
+        if self.deferred_inlines.is_empty() {
+            return;
+        }
+
+        if statement_contains_call(statement) {
+            self.deferred_inlines
+                .retain(|_, rvalue| !references_mutable_state(rvalue));
         }
     }
 
@@ -5046,3 +5058,64 @@ fn inline_local_in_rvalue(rvalue: &mut RValue, local: &RcLocal, replacement: &RV
         inline_local_in_rvalue(rv, local, replacement);
     }
 }
+
+/// Check if an rvalue references mutable state that could be changed by a function call.
+/// This includes table field accesses (Index), length operations (Unary #), and
+/// method calls. Simple locals and literals are not mutable by external calls.
+/// Check if an rvalue references state that is sensitive to function calls.
+/// Only Length (#t) operations are considered mutable — they depend on the table's
+/// array length, which can change if elements are added/removed by a call.
+/// Index operations (t[k]) are NOT flagged because calls rarely modify specific
+/// field values of unrelated tables, and flagging them causes too many false positives.
+fn references_mutable_state(rvalue: &RValue) -> bool {
+    match rvalue {
+        // Table field access: NOT flagged. Writing t[k] = v in an assignment is handled
+        // separately. Calls that could change t[k] would need a reference to t, which
+        // is rare for deferred inline values (they're typically local table refs).
+        RValue::Index(idx) => {
+            // Recurse into sub-expressions (e.g., t[#arr] contains a Length)
+            references_mutable_state(&idx.left) || references_mutable_state(&idx.right)
+        }
+        // Length of a table like #self.fillTypes — could change if table is modified
+        RValue::Unary(unary) => {
+            if unary.operation == UnaryOperation::Length {
+                true
+            } else {
+                references_mutable_state(&unary.value)
+            }
+        }
+        RValue::Binary(binary) => {
+            references_mutable_state(&binary.left) || references_mutable_state(&binary.right)
+        }
+        // Locals, literals, closures are safe — they can't be changed by external calls
+        RValue::Local(_) | RValue::Literal(_) | RValue::Closure(_) => false,
+        // Calls have side effects and shouldn't be in deferred_inlines anyway
+        RValue::Call(_) | RValue::MethodCall(_) | RValue::Select(_) => true,
+        RValue::Table(table) => table.0.iter().any(|(k, v)| {
+            k.as_ref().map_or(false, references_mutable_state) || references_mutable_state(v)
+        }),
+        _ => false,
+    }
+}
+
+/// Check if a statement contains any Call or MethodCall in its RValues.
+/// This is used to distinguish function calls (which can mutate anything) from
+/// simple table field writes (which can only mutate one specific table).
+fn statement_contains_call(statement: &Statement) -> bool {
+    fn rvalue_contains_call(rvalue: &RValue) -> bool {
+        match rvalue {
+            RValue::Call(_) | RValue::MethodCall(_) | RValue::Select(_) => true,
+            _ => rvalue.rvalues().iter().any(|rv| rvalue_contains_call(rv)),
+        }
+    }
+
+    // Check direct call/method-call statements
+    match statement {
+        Statement::Call(_) | Statement::MethodCall(_) => return true,
+        _ => {}
+    }
+
+    // Check RValues within the statement (e.g. RHS of assignments)
+    statement.rvalues().iter().any(|rv| rvalue_contains_call(rv))
+}
+

--- a/ast/src/local.rs
+++ b/ast/src/local.rs
@@ -79,6 +79,11 @@ impl RcLocal {
             lock.0 = name;
         }
     }
+
+    /// Unconditionally set the name of this local
+    pub fn set_name(&self, name: Option<String>) {
+        self.0 .0.lock().0 = name;
+    }
 }
 
 impl LocalRw for RcLocal {

--- a/cfg/src/ssa/destruct.rs
+++ b/cfg/src/ssa/destruct.rs
@@ -106,6 +106,8 @@ impl<'a> Destructor<'a> {
 
         super::construct::apply_local_map(self.function, self.build_local_map());
 
+        Self::fix_duplicate_for_var_names(self.function);
+
         //crate::dot::render_to(self.function, &mut std::io::stdout()).unwrap();
 
         self.sequentialize();
@@ -245,11 +247,12 @@ impl<'a> Destructor<'a> {
             if con_class.is_empty() {
                 continue;
             }
-            // Prefer a local with a debug name if any exists in the congruence class
-            // Fall back to the first (by dominator order) if none have names
+            // Prefer a local with a meaningful debug name (not "_") if any exists.
+            // Fall back to any named local, then to the first by dominator order.
             let new_local = con_class
                 .iter()
-                .find(|(_, l)| l.name().is_some())
+                .find(|(_, l)| l.name().as_deref().is_some_and(|n| n != "_"))
+                .or_else(|| con_class.iter().find(|(_, l)| l.name().is_some()))
                 .map(|(_, l)| l)
                 .unwrap_or_else(|| con_class.iter().next().unwrap().1);
             // TODO: see apply_local_map TODO,
@@ -259,6 +262,50 @@ impl<'a> Destructor<'a> {
             }
         }
         map
+    }
+
+    /// After apply_local_map, different congruence classes may have representatives
+    /// with the same debug name. When two such locals appear as res_locals of the
+    /// same GenericForNext (which becomes `for x, x in ...`), we need to rename
+    /// duplicates. Since apply_local_map has already run, each res_local is a
+    /// distinct RcLocal from a different congruence class, so set_name only affects
+    /// references within that class.
+    ///
+    /// In generic for-loops (`for k, v in ...`), the first variable is the key and
+    /// later ones are values. When both got the same name from the bytecode debug
+    /// info, the earlier (key) variable is the one the programmer likely left as `_`,
+    /// so we rename the earlier occurrence.
+    fn fix_duplicate_for_var_names(function: &mut Function) {
+        for node in function.graph().node_indices().collect::<Vec<_>>() {
+            for stat in function.block_mut(node).unwrap().iter_mut() {
+                let res_locals = match stat {
+                    ast::Statement::GenericForNext(gfn) => {
+                        gfn.res_locals
+                            .iter()
+                            .filter_map(|lv| lv.as_local())
+                            .collect::<Vec<_>>()
+                    }
+                    _ => continue,
+                };
+
+                // Collect all names and their positions, then rename earlier
+                // occurrences of duplicated names to `_`.
+                let mut last_seen: FxHashMap<String, usize> = FxHashMap::default();
+                let mut to_rename = Vec::new();
+
+                for (i, local) in res_locals.iter().enumerate() {
+                    if let Some(name) = local.name() {
+                        if let Some(prev_idx) = last_seen.insert(name, i) {
+                            to_rename.push(prev_idx);
+                        }
+                    }
+                }
+
+                for idx in to_rename {
+                    res_locals[idx].set_name(Some("_".to_string()));
+                }
+            }
+        }
     }
 
     // TODO: combine with compute value interference
@@ -311,14 +358,18 @@ impl<'a> Destructor<'a> {
                 }
             }
 
-            if let Some((_, edge)) = self.function.edges_to_block(node).next() {
-                for (param_index, (param, _)) in
-                    edge.arguments.iter().enumerate().collect::<Vec<_>>()
-                {
-                    self.local_defs.insert(
-                        param.clone(),
-                        (dominator_index, node, ParamOrStatIndex::Param(param_index)),
-                    );
+            // Collect params from ALL incoming edges (not just the first).
+            // Different edges may have different param sets after structuring passes.
+            let mut param_index = 0;
+            for (_, edge) in self.function.edges_to_block(node) {
+                for (param, _) in edge.arguments.iter() {
+                    if !self.local_defs.contains_key(param) {
+                        self.local_defs.insert(
+                            param.clone(),
+                            (dominator_index, node, ParamOrStatIndex::Param(param_index)),
+                        );
+                        param_index += 1;
+                    }
                 }
             }
             for (stat_index, stat) in self.function.block(node).unwrap().0.iter().enumerate() {

--- a/cfg/src/ssa/structuring.rs
+++ b/cfg/src/ssa/structuring.rs
@@ -7,7 +7,7 @@ use petgraph::{
     stable_graph::{EdgeIndex, NodeIndex},
     visit::{DfsPostOrder, EdgeRef},
 };
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use tuple::Map;
 
 use crate::{
@@ -268,6 +268,61 @@ fn match_conditional_sequence(
     }
 }
 
+/// Apply a single conditional sequence pattern, merging two nodes into one compound condition.
+fn apply_conditional_sequence(function: &mut Function, pattern: ConditionalSequencePattern) {
+    let second_to_sc_edges = function
+        .edges(pattern.second_node)
+        .filter(|e| e.target() == pattern.short_circuit)
+        .collect::<Vec<_>>();
+    assert!(second_to_sc_edges.len() == 1);
+    let second_to_sc_args = second_to_sc_edges[0].weight().arguments.clone();
+    let first_to_sc_edges = function
+        .edges(pattern.first_node)
+        .filter(|e| e.target() == pattern.short_circuit)
+        .collect::<Vec<_>>();
+    assert!(first_to_sc_edges.len() == 1);
+    let first_to_sc_edge = first_to_sc_edges[0].id();
+    for arg in &mut function
+        .graph_mut()
+        .edge_weight_mut(first_to_sc_edge)
+        .unwrap()
+        .arguments
+    {
+        if let Some(new_arg) = second_to_sc_args.iter().find(|(k, _)| k == &arg.0) {
+            *arg = new_arg.clone();
+        }
+    }
+
+    let second_terminator = function.conditional_edges(pattern.second_node).unwrap();
+    let other_edge = if second_terminator.0.target() == pattern.short_circuit {
+        second_terminator.1
+    } else {
+        second_terminator.0
+    };
+    let other_edge = other_edge.id();
+    assert!(skip_over_node(function, pattern.first_node, other_edge));
+
+    let mut removed_block = function.remove_block(pattern.second_node).unwrap();
+    let first_node = pattern.first_node;
+    if pattern.assign {
+        let assign = removed_block.first_mut().unwrap().as_assign_mut().unwrap();
+        assign.right = vec![pattern.final_condition.reduce()];
+    } else {
+        let removed_if = removed_block.last_mut().unwrap().as_if_mut().unwrap();
+        removed_if.condition = pattern.final_condition.reduce_condition();
+    }
+    if pattern.inverted {
+        let removed_if = removed_block.last_mut().unwrap().as_if_mut().unwrap();
+        // TODO: unnecessary clone?
+        removed_if.condition =
+            ast::Unary::new(removed_if.condition.clone(), UnaryOperation::Not)
+                .reduce_condition();
+    }
+    let first_block = function.block_mut(first_node).unwrap();
+    first_block.pop();
+    first_block.extend(removed_block.0);
+}
+
 pub fn structure_conditionals(function: &mut Function) -> bool {
     let mut did_structure = false;
     // TODO: does this need to be in dfs post order?
@@ -280,62 +335,20 @@ pub fn structure_conditionals(function: &mut Function) -> bool {
             did_structure = true;
         }
 
-        if let Some(pattern) = match_conditional_sequence(function, node)
-            // TODO: can we continue?
-            && &Some(pattern.second_node) != function.entry()
-        {
-            let second_to_sc_edges = function
-                .edges(pattern.second_node)
-                .filter(|e| e.target() == pattern.short_circuit)
-                .collect::<Vec<_>>();
-            assert!(second_to_sc_edges.len() == 1);
-            let second_to_sc_args = second_to_sc_edges[0].weight().arguments.clone();
-            let first_to_sc_edges = function
-                .edges(pattern.first_node)
-                .filter(|e| e.target() == pattern.short_circuit)
-                .collect::<Vec<_>>();
-            assert!(first_to_sc_edges.len() == 1);
-            let first_to_sc_edge = first_to_sc_edges[0].id();
-            for arg in &mut function
-                .graph_mut()
-                .edge_weight_mut(first_to_sc_edge)
-                .unwrap()
-                .arguments
+        // Keep trying to match conditional sequences from this node until no more matches.
+        // This handles nested compound conditions like `A and (B or C)` which require
+        // multiple merge passes - first merging B and C, then merging A with (B or C).
+        loop {
+            if let Some(pattern) = match_conditional_sequence(function, node)
+                // TODO: can we continue?
+                && &Some(pattern.second_node) != function.entry()
             {
-                if let Some(new_arg) = second_to_sc_args.iter().find(|(k, _)| k == &arg.0) {
-                    *arg = new_arg.clone();
-                }
-            }
-
-            let second_terminator = function.conditional_edges(pattern.second_node).unwrap();
-            let other_edge = if second_terminator.0.target() == pattern.short_circuit {
-                second_terminator.1
+                apply_conditional_sequence(function, pattern);
+                did_structure = true;
+                // Continue loop to try matching again from the same node
             } else {
-                second_terminator.0
-            };
-            let other_edge = other_edge.id();
-            assert!(skip_over_node(function, pattern.first_node, other_edge));
-
-            let mut removed_block = function.remove_block(pattern.second_node).unwrap();
-            let first_node = pattern.first_node;
-            if pattern.assign {
-                let assign = removed_block.first_mut().unwrap().as_assign_mut().unwrap();
-                assign.right = vec![pattern.final_condition.reduce()];
-            } else {
-                let removed_if = removed_block.last_mut().unwrap().as_if_mut().unwrap();
-                removed_if.condition = pattern.final_condition.reduce_condition();
+                break;
             }
-            if pattern.inverted {
-                let removed_if = removed_block.last_mut().unwrap().as_if_mut().unwrap();
-                // TODO: unnecessary clone?
-                removed_if.condition =
-                    ast::Unary::new(removed_if.condition.clone(), UnaryOperation::Not)
-                        .reduce_condition();
-            }
-            let first_block = function.block_mut(first_node).unwrap();
-            first_block.pop();
-            first_block.extend(removed_block.0);
-            did_structure = true;
         }
 
         did_structure |= try_remove_unnecessary_condition(function, node);
@@ -955,5 +968,188 @@ pub fn structure_jumps(function: &mut Function, dominators: &Dominators<NodeInde
             }
         }
     }
+    did_structure
+}
+
+/// Match and structure or-chain patterns where multiple conditional nodes all jump
+/// to the same target on their "then" branch, forming an or-chain.
+///
+/// Pattern in CFG:
+/// ```
+/// A: if cond1 then -> BODY else -> B
+/// B: if cond2 then -> BODY else -> C
+/// C: if cond3 then -> BODY else -> EXIT
+/// ```
+///
+/// Should become: `if cond1 or cond2 or cond3 then BODY else EXIT`
+pub fn structure_or_chains(function: &mut Function) -> bool {
+    let mut did_structure = false;
+
+    // Find nodes that are targets of multiple conditional "then" edges
+    let mut then_target_counts: FxHashMap<NodeIndex, Vec<NodeIndex>> = FxHashMap::default();
+
+    for node in function.graph().node_indices().collect_vec() {
+        if let Some((then_edge, _else_edge)) = function.conditional_edges(node) {
+            let target = then_edge.target();
+            then_target_counts.entry(target).or_default().push(node);
+        }
+    }
+
+    for (body_target, sources) in then_target_counts {
+        if sources.len() < 2 {
+            continue;
+        }
+
+        // Check if these sources form a chain: A -> B -> C -> ... where each
+        // node's "else" edge goes to the next node in the chain
+        let mut remaining: FxHashSet<_> = sources.iter().cloned().collect();
+
+        // Find the start of the chain - a node whose predecessor is NOT in our source set
+        let mut chain_start = None;
+        for &node in &sources {
+            let has_pred_in_sources = function
+                .predecessor_blocks(node)
+                .any(|p| remaining.contains(&p));
+            if !has_pred_in_sources {
+                chain_start = Some(node);
+                break;
+            }
+        }
+
+        let Some(start) = chain_start else { continue };
+
+        // Build the chain by following else edges
+        let mut chain: Vec<NodeIndex> = Vec::new();
+        let mut current = start;
+        while remaining.remove(&current) {
+            chain.push(current);
+            if let Some((_then_edge, else_edge)) = function.conditional_edges(current) {
+                let else_target = else_edge.target();
+                if remaining.contains(&else_target) {
+                    current = else_target;
+                } else {
+                    break;
+                }
+            } else {
+                break;
+            }
+        }
+
+        if chain.len() < 2 {
+            continue;
+        }
+
+        // Verify the chain structure
+        let mut valid = true;
+        let mut conditions: Vec<ast::RValue> = Vec::new();
+
+        for (i, &node) in chain.iter().enumerate() {
+            let block = function.block(node).unwrap();
+
+            let Some(if_stat) = block.last().and_then(|s| s.as_if()) else {
+                valid = false;
+                break;
+            };
+
+            if block.len() != 1 {
+                valid = false;
+                break;
+            }
+
+            conditions.push(if_stat.condition.clone());
+
+            let Some((then_edge, else_edge)) = function.conditional_edges(node) else {
+                valid = false;
+                break;
+            };
+
+            if then_edge.target() != body_target {
+                valid = false;
+                break;
+            }
+
+            if i < chain.len() - 1 {
+                if else_edge.target() != chain[i + 1] {
+                    valid = false;
+                    break;
+                }
+            }
+        }
+
+        if !valid || conditions.is_empty() {
+            continue;
+        }
+
+        let last_node = *chain.last().unwrap();
+        let Some((_then_edge, else_edge)) = function.conditional_edges(last_node) else {
+            continue;
+        };
+        let else_destination = else_edge.target();
+
+        if else_destination == body_target {
+            continue;
+        }
+
+        // Check if any edge in the chain carries arguments (phi params).
+        // If so, we can't safely merge because each chain node has a separate
+        // edge to body_target with potentially different arguments.
+        let mut has_args = false;
+        for &node in &chain {
+            if let Some((then_edge, else_edge)) = function.conditional_edges(node) {
+                if !then_edge.weight().arguments.is_empty() || !else_edge.weight().arguments.is_empty() {
+                    has_args = true;
+                    break;
+                }
+            }
+        }
+        if !has_args {
+            for &node in &chain[..chain.len() - 1] {
+                if let Some((_, else_edge)) = function.conditional_edges(node) {
+                    if !else_edge.weight().arguments.is_empty() {
+                        has_args = true;
+                        break;
+                    }
+                }
+            }
+        }
+        if has_args {
+            continue;
+        }
+
+        // Build the combined or condition
+        let mut combined_condition = conditions[0].clone();
+        for cond in &conditions[1..] {
+            combined_condition = ast::Binary::new(
+                combined_condition,
+                cond.clone(),
+                ast::BinaryOperation::Or,
+            ).into();
+        }
+
+        // Update the first node's condition
+        let first_node = chain[0];
+        {
+            let block = function.block_mut(first_node).unwrap();
+            let if_stat = block.last_mut().unwrap().as_if_mut().unwrap();
+            if_stat.condition = combined_condition;
+        }
+
+        // Update edges
+        function.set_edges(
+            first_node,
+            vec![
+                (body_target, BlockEdge::new(BranchType::Then)),
+                (else_destination, BlockEdge::new(BranchType::Else)),
+            ],
+        );
+
+        // Remove intermediate nodes
+        for &node in &chain[1..] {
+            function.remove_block(node);
+        }
+
+        did_structure = true;
+    }
+
     did_structure
 }

--- a/luau-lifter/src/lib.rs
+++ b/luau-lifter/src/lib.rs
@@ -18,7 +18,7 @@ use cfg::{
     function::Function,
     ssa::{
         self,
-        structuring::{structure_conditionals, structure_jumps},
+        structuring::{structure_conditionals, structure_jumps, structure_or_chains},
     },
 };
 use indexmap::IndexMap;
@@ -272,6 +272,12 @@ fn decompile_function(
         if structure_conditionals(&mut function) {
             changed = true;
             dominators_valid = false; // CFG changed, invalidate dominators
+        }
+
+        // Structure or-chains: multiple conditions jumping to same target
+        if structure_or_chains(&mut function) {
+            changed = true;
+            dominators_valid = false;
         }
 
         let mut local_map = FxHashMap::default();

--- a/luau-lifter/src/lifter.rs
+++ b/luau-lifter/src/lifter.rs
@@ -165,7 +165,7 @@ impl<'a> Lifter<'a> {
             let index = info.register as usize;
             // Skip if already in map (e.g., parameters) - but only if it has a valid name
             if let Some(existing) = self.register_map.get(&(index, 0)) {
-                if existing.name().is_some() {
+                if existing.name().as_deref().is_some_and(|n| n != "_") {
                     continue;
                 }
             }


### PR DESCRIPTION
## Summary

Multiple decompilation quality improvements across control flow structuring, SSA destruction, inline temporaries, and the lifter.

## Changes

### 1. Or-chain structuring (eliminates gotos)

New pass that merges multiple conditional nodes jumping to the same target into compound `or` conditions. Also fixes conditional sequence merging to loop until exhausted, handling nested patterns like `A and (B or C)`.

**Before:**
```lua
if cond1 then goto BODY end
if cond2 then goto BODY end
if not cond3 then goto EXIT end
::BODY::
  ...
```

**After:**
```lua
if cond1 or cond2 or cond3 then
  ...
end
```

### 2. Congruence class representative prefers real names over `_`

SSA destruction's `build_local_map` now skips `_` when selecting the representative name for a congruence class. Previously, when a `_` local from a for-loop key was coalesced with a meaningful variable, `_` could win and all references would lose their name.

**Before:**
```lua
for _, _ in ipairs(childVehicles) do
  if _.getAIDischargeNodes ~= nil then
```

**After:**
```lua
for dischargeNode, childVehicle in ipairs(childVehicles) do
  if childVehicle.getAIDischargeNodes ~= nil then
```

### 3. Duplicate for-loop variable names

Post-pass in SSA destruction detects when two different congruence classes select representatives with the same name that both appear as `GenericForNext` result locals, and renames the earlier (key) duplicate to `_`.

**Before:**
```lua
for wheel, wheel in pairs(spec.wheels) do
  wheel.physics:update()
```

**After:**
```lua
for _, wheel in pairs(spec.wheels) do
  wheel.physics:update()
```

### 4. Iterator inlining relaxed matching

The adjacent `Assign(call) + GenericFor` inlining pattern now matches by arity + all-locals check instead of requiring name equality. After SSA destruction, the assignment LHS and for-loop iterator locals can end up in different congruence classes with different names.

**Before:**
```lua
canCancel, v32_, v33_ = pairs(self.jobTypeInstances)
for typeIndex, instance in job, v32_, v33_ do
```

**After:**
```lua
for typeIndex, instance in pairs(self.jobTypeInstances) do
```

### 5. Deferred inline invalidation past mutating calls

Length operations (`#t`) in deferred inlines are now invalidated when a function/method call is encountered, since calls like `table.insert` can change the table length between the deferred expression and its inline target.

**Before:**
```lua
-- #self.fillTypes was captured before table.insert, then inlined after
fillTypeDesc.index = #self.fillTypes  -- stale value, should be #self.fillTypes + 1
```

**After:**
```lua
local numFillTypes = #self.fillTypes
-- ... table.insert modifies self.fillTypes ...
fillTypeDesc.index = #self.fillTypes + 1  -- re-read after mutation
```

### 6. Lifter: `_` no longer blocks real debug names

Register debug name pre-population now treats `_` as overridable, so when a register is reused across scopes (e.g., `_` in a for-loop key, then `childVehicle` in a different scope), the meaningful name wins.

### 7. SSA build_def_use collects params from all edges

`build_def_use` now iterates ALL incoming edges to a block, not just the first. This fixes panics when different edges carry different parameter sets after structuring passes.

## Test results

Decompiling the full FS25 script corpus (1832 files):
- **0 panics** (was crashing on several files)
- **0 duplicate for-loop variables** (was ~59 `for x, x in` cases)
- **0 `for _, _ in` with value used as real variable** (was 34 cases)
- **0 undefined temps in InGameMenuMapFrame** (was several `v##_` temps from iterator mismatch)