### PR TITLE
fix: SSA copy propagation naming and for-loop init inlining

### DIFF
--- a/ast/src/inline_temporaries.rs
+++ b/ast/src/inline_temporaries.rs
@@ -3278,21 +3278,36 @@ fn collect_local_usage_in_rvalue(
     }
 }
 
+fn is_dead_local(local: &RcLocal, dead_locals: &FxHashSet<RcLocal>) -> bool {
+    dead_locals.contains(local)
+        || dead_locals
+            .iter()
+            .any(|d| d.name().is_some() && d.name() == local.name())
+}
+
 fn remove_dead_local_assignments(block: &mut Block, dead_locals: &FxHashSet<RcLocal>) {
     // Remove assignments to dead locals
-    block.retain(|stmt| {
-        if let Some(assign) = stmt.as_assign() {
-            // Check if this assignment ONLY writes to dead locals
-            // and the RHS has no side effects
-            if assign.left.len() == 1 && !assign.right.iter().any(|r| r.has_side_effects()) {
-                if let Some(local) = assign.left[0].as_local() {
-                    let is_dead = dead_locals.contains(local)
-                        || dead_locals
-                            .iter()
-                            .any(|d| d.name().is_some() && d.name() == local.name());
-                    if is_dead {
-                        return false; // Remove this statement
-                    }
+    block.retain_mut(|stmt| {
+        if let Statement::Assign(assign) = stmt {
+            // Check if ALL LHS lvalues are dead locals and RHS has no side effects
+            let all_dead = !assign.left.is_empty()
+                && assign.left.iter().all(|lv| {
+                    lv.as_local().map_or(false, |l| is_dead_local(l, dead_locals))
+                })
+                && !assign.right.iter().any(|r| r.has_side_effects());
+            if all_dead {
+                return false; // Remove entire statement
+            }
+
+            // For bare declarations (prefix=true, empty RHS), remove dead locals
+            // from the LHS while keeping live ones
+            if assign.prefix && assign.right.is_empty() && assign.left.len() > 1 {
+                assign.left.retain(|lv| {
+                    lv.as_local()
+                        .map_or(true, |l| !is_dead_local(l, dead_locals))
+                });
+                if assign.left.is_empty() {
+                    return false; // All locals were dead
                 }
             }
         }

--- a/ast/src/local_declarations.rs
+++ b/ast/src/local_declarations.rs
@@ -176,12 +176,54 @@ impl LocalDeclarer {
                 .insert(local);
         }
 
+        // Build a map: node → { name → earliest stat_index of declaration }.
+        let mut node_declared_at: FxHashMap<NodeIndex, FxHashMap<String, usize>> =
+            FxHashMap::default();
+        for (ByAddress(block), declarations) in &self.declarations {
+            let node = self.block_to_node[&ByAddress(block.clone())];
+            let map = node_declared_at.entry(node).or_default();
+            for (&stat_index, locals) in declarations {
+                for local in locals {
+                    if let Some(name) = local.name() {
+                        map.entry(name)
+                            .and_modify(|idx| *idx = (*idx).min(stat_index))
+                            .or_insert(stat_index);
+                    }
+                }
+            }
+        }
+
         for (ByAddress(block), mut declarations) in self.declarations {
+            // Collect names already declared in ancestor scopes, but only if the
+            // ancestor declaration is at or before the statement where the child
+            // block is attached.  This prevents suppressing a declaration when the
+            // ancestor's `local` actually comes AFTER the child block.
+            let node = self.block_to_node[&ByAddress(block.clone())];
+            let mut ancestor_names: FxHashSet<String> = FxHashSet::default();
+            let mut current = node;
+            while let Some(parent) = self
+                .graph
+                .neighbors_directed(current, Direction::Incoming)
+                .next()
+            {
+                // stat_index stored in the current node is where this child
+                // block sits relative to its parent.
+                let child_stat_index = self.graph.node_weight(current).unwrap().1;
+                if let Some(decls) = node_declared_at.get(&parent) {
+                    for (name, &decl_idx) in decls {
+                        if decl_idx <= child_stat_index {
+                            ancestor_names.insert(name.clone());
+                        }
+                    }
+                }
+                current = parent;
+            }
+
             // After SSA destruction, multiple RcLocal instances can share the same
             // name (different SSA versions of the same source variable). Only the
             // first (lowest stat_index) should get a `local` prefix. Filter out
-            // duplicates in a forward pass before applying.
-            let mut declared_names: FxHashSet<String> = FxHashSet::default();
+            // duplicates within this block AND against ancestor scopes.
+            let mut declared_names: FxHashSet<String> = ancestor_names;
             // BTreeMap iterates in ascending key order (lowest stat_index first)
             for (_stat_index, locals) in declarations.iter_mut() {
                 locals.retain(|l| {

--- a/cfg/src/function.rs
+++ b/cfg/src/function.rs
@@ -78,19 +78,40 @@ impl Function {
     /// with a small scope extension to handle Luau's scope_start offset.
     pub fn get_local_debug_name(&self, local: &RcLocal, node: NodeIndex, stat_index: usize) -> Option<String> {
         let register = self.local_to_register.get(local)?;
-        let pc = self.statement_pc.get(&(node, stat_index)).copied()?;
+        let pc = self.statement_pc.get(&(node, stat_index)).copied()
+            .or_else(|| {
+                // Phi params at block entry (stat_index=0) don't have statement PCs.
+                // Use the first available PC in this block as an approximation.
+                self.statement_pc.iter()
+                    .filter(|((n, _), _)| *n == node)
+                    .min_by_key(|((_, si), _)| *si)
+                    .map(|(_, &pc)| pc)
+            })?;
         let name = self.get_debug_name_for_register(*register, pc)
             .or_else(|| {
-                // Fallback: if the register has exactly one unique name across all scopes,
-                // use it. This handles cases where the definition PC falls before the
-                // debug scope_start (common with Luau's compiler debug info).
-                let names: rustc_hash::FxHashSet<&str> = self.register_debug_info
+                let entries: Vec<_> = self.register_debug_info
                     .iter()
                     .filter(|info| info.register == *register && !info.name.starts_with('('))
-                    .map(|info| info.name.as_str())
                     .collect();
+                let names: rustc_hash::FxHashSet<&str> = entries.iter().map(|e| e.name.as_str()).collect();
                 if names.len() == 1 {
-                    Some(*names.iter().next().unwrap())
+                    // Only one name for this register — use it regardless of scope.
+                    Some(entries[0].name.as_str())
+                } else if names.len() > 1 {
+                    // Multiple names for this register (reused across scopes).
+                    // Try two strategies:
+                    // 1. Find nearest scope starting soon after our PC (assignment
+                    //    just before scope_start — up to 10 instructions gap).
+                    // 2. Find most recently ended scope before our PC.
+                    entries.iter()
+                        .filter(|info| info.scope_start > pc && info.scope_start <= pc + 10)
+                        .min_by_key(|info| info.scope_start)
+                        .or_else(|| {
+                            entries.iter()
+                                .filter(|info| info.scope_end <= pc + 5)
+                                .max_by_key(|info| info.scope_end)
+                        })
+                        .map(|info| info.name.as_str())
                 } else {
                     None
                 }

--- a/cfg/src/ssa/construct.rs
+++ b/cfg/src/ssa/construct.rs
@@ -449,13 +449,14 @@ impl<'a> SsaConstructor<'a> {
                         let from_has_name = from.name().is_some();
                         let to_has_name = to.name().is_some();
 
-                        // When both locals have debug names AND originate from
-                        // different registers, they represent genuinely different
-                        // source variables.  Do not merge them — keep the copy.
-                        // Example: `profileClass = string.lower(profileClass)` stores
-                        // the result in R0 while `currentProfileIndex` lives in R1.
-                        // Merging would make all R0 uses show as `currentProfileIndex`.
-                        if from_has_name && to_has_name && from_old != to_old {
+                        // When both locals have debug names, do not merge if:
+                        // 1. They come from different registers (genuinely different
+                        //    source variables), OR
+                        // 2. They have different names (same register reused for
+                        //    different variables in different scopes).
+                        if from_has_name && to_has_name
+                            && (from_old != to_old || from.name() != to.name())
+                        {
                             // Keep both variables; do not eliminate the copy.
                         } else if from_has_name && !to_has_name {
                             // from has name, to doesn't -> keep from, map to → from

--- a/cfg/src/ssa/construct.rs
+++ b/cfg/src/ssa/construct.rs
@@ -446,20 +446,27 @@ impl<'a> SsaConstructor<'a> {
                     if !self.new_upvalues_in.contains_key(to_old)
                         && !self.upvalues_passed.contains_key(to_old)
                     {
-                        // Prefer keeping the variable with a debug name.
-                        // If `from` has a name and `to` doesn't, map `to → from`
-                        // so the named variable is preserved in the output.
                         let from_has_name = from.name().is_some();
                         let to_has_name = to.name().is_some();
-                        if from_has_name && !to_has_name {
+
+                        // When both locals have debug names AND originate from
+                        // different registers, they represent genuinely different
+                        // source variables.  Do not merge them — keep the copy.
+                        // Example: `profileClass = string.lower(profileClass)` stores
+                        // the result in R0 while `currentProfileIndex` lives in R1.
+                        // Merging would make all R0 uses show as `currentProfileIndex`.
+                        if from_has_name && to_has_name && from_old != to_old {
+                            // Keep both variables; do not eliminate the copy.
+                        } else if from_has_name && !to_has_name {
                             // from has name, to doesn't -> keep from, map to → from
                             self.local_map.insert(to.clone(), from.clone());
+                            block[index] = ast::Empty {}.into();
                         } else {
-                            // Either: to has name, or neither has name, or both have names
-                            // -> keep to (original behavior)
+                            // Either: to has name, or neither has name, or both
+                            // have names from the same register -> keep to
                             self.local_map.insert(from.clone(), to.clone());
+                            block[index] = ast::Empty {}.into();
                         }
-                        block[index] = ast::Empty {}.into();
                     }
                 }
             }

--- a/cfg/src/ssa/inline.rs
+++ b/cfg/src/ssa/inline.rs
@@ -527,27 +527,25 @@ pub fn inline(
         }
     }
 
-    // Collect all locals involved in for loop constructs - these should not be inlined
-    // to preserve the link between NumForInit/NumForNext and the loop body.
+    // Collect locals *written* by for loop constructs — these are internal
+    // control variables that must not be inlined away.  Locals that are only
+    // *read* (the init/limit/step expressions) should remain inlineable so
+    // that `local i = #t; for i = i, 1, -1` becomes `for i = #t, 1, -1`.
     let mut for_loop_locals = FxHashSet::default();
     for node in function.graph().node_indices() {
         if let Some(block) = function.block(node) {
             for stat in &block.0 {
                 match stat {
                     ast::Statement::NumForInit(nfi) => {
-                        for_loop_locals.extend(nfi.values_read().into_iter().cloned());
                         for_loop_locals.extend(nfi.values_written().into_iter().cloned());
                     }
                     ast::Statement::NumForNext(nfn) => {
-                        for_loop_locals.extend(nfn.values_read().into_iter().cloned());
                         for_loop_locals.extend(nfn.values_written().into_iter().cloned());
                     }
                     ast::Statement::GenericForInit(gfi) => {
-                        for_loop_locals.extend(gfi.values_read().into_iter().cloned());
                         for_loop_locals.extend(gfi.values_written().into_iter().cloned());
                     }
                     ast::Statement::GenericForNext(gfn) => {
-                        for_loop_locals.extend(gfn.values_read().into_iter().cloned());
                         for_loop_locals.extend(gfn.values_written().into_iter().cloned());
                     }
                     _ => {}


### PR DESCRIPTION
## Summary

Five fixes for decompiler output quality:

### 1. SSA copy propagation naming (closes #20)

When both sides of a copy have debug names from **different registers**, they represent different source variables. The copy propagation was unconditionally merging them, causing the LHS to inherit the RHS name.

**Before:**
```lua
function Utils.getPerformanceClassIndex(profileClass)
	local currentProfileIndex = string.lower(profileClass)
	currentProfileIndex = GS_PROFILE_LOW
	if currentProfileIndex == "very low" then  -- wrong! testing a constant
		return GS_PROFILE_VERY_LOW
	end
```

**After:**
```lua
function Utils.getPerformanceClassIndex(profileClass)
	profileClass = string.lower(profileClass)
	local currentProfileIndex = GS_PROFILE_LOW
	if profileClass == "very low" then  -- correct! testing the lowered string
		return GS_PROFILE_VERY_LOW
	end
```

921 files affected across the test corpus.

### 2. For-loop init expression inlining (closes #23)

The SSA inline pass marked **all** locals involved in for-loop constructs as non-inlineable (`usize::MAX` usage count). This prevented init/limit/step expressions from being inlined into the for-loop header.

Now only the **written** control variables are protected. Read locals (the init expressions) remain inlineable.

**Before:**
```lua
local i = #self.modBalesToLoad
for i = i, 1, -1 do
```

**After:**
```lua
for i = #self.modBalesToLoad, 1, -1 do
```

`for x = x,` occurrences reduced from **2,458 to 67** (97%). The 67 remaining are legitimate patterns where the variable is modified before the loop.

### 3. Inner-scope variable shadowing (closes #22)

After SSA destruction, different SSA versions of the same source variable could end up in different scopes. The `local_declarations` pass would declare each independently, causing inner scopes to incorrectly shadow outer variables.

Now checks ancestor blocks for existing declarations of the same name, but only when the ancestor declaration **precedes** the child block's attachment point (prevents over-suppression).

**Before:**
```lua
local numDigits = 0
for i = 1, textMask:len() do
    if textMask:sub(i, i) == "0" then
        numDigits = numDigits + 1
    else
        local numDigits          -- shadows outer! reads uninitialized value
        if numDigits > 0 then
```

**After:**
```lua
local numDigits = 0
for i = 1, textMask:len() do
    if textMask:sub(i, i) == "0" then
        numDigits = numDigits + 1
    else
        if numDigits > 0 then   -- correctly references outer numDigits
```

378 files affected across the test corpus.

### 4. Recover debug names for reused registers

Two improvements to the debug name lookup that recover variable names for reused registers:

1. **Phi param PC fallback**: SSA phi parameters at block entry have no statement PC. Now falls back to the first available PC in the block.

2. **Multi-scope register resolution**: When a register is reused across scopes (e.g., R5 is `dx` at PC 25-37 then `u` at PC 46-116), the assignment PC often falls before the debug scope starts. The lookup now finds the nearest upcoming scope within 10 instructions, or the most recently ended scope.

Also extends the copy propagation guard to prevent merging same-register variables with different names.

**Before:**
```lua
local v6_ = x + math.sin(r)       -- unnamed temp
local dz = z - 1 - math.cos(r)
local u1 = MathUtil.vector2Length(v6_, dz)
```

**After:**
```lua
local dx = x + math.sin(r)        -- recovered name
local dz = z - 1 - math.cos(r)
local u1 = MathUtil.vector2Length(dx, dz)
```

Temp variable leaks reduced from **284 occurrences in 55 files** to **105 in 30 files** (63% reduction).

### 5. Remove dead locals from bare declarations

After `collapse_multi_return_assignments` rewrites multi-return patterns like `v1, v2, v3 = call()` → `t.x, t.y, t.z = call()`, the original locals become dead. However, `declare_locals` had already created bare `local v3_, v4_` declarations for them, and `remove_dead_local_assignments` only handled single-local assignments (`left.len() == 1`).

Now handles multi-local dead assignments and strips dead locals from bare declarations.

**Before:**
```lua
data = self.bunkerSiloArea
inputFillTypeName = self.bunkerSiloArea
inputFillTypeIndex = self.bunkerSiloArea
local v3_, v4_                    -- dead, never used
data.wx, inputFillTypeName.wy, inputFillTypeIndex.wz = getWorldTranslation(self.bunkerSiloArea.width)
```

**After:**
```lua
data = self.bunkerSiloArea
inputFillTypeName = self.bunkerSiloArea
inputFillTypeIndex = self.bunkerSiloArea
data.wx, inputFillTypeName.wy, inputFillTypeIndex.wz = getWorldTranslation(self.bunkerSiloArea.width)
```

Temp variable leaks reduced from **127 occurrences in 30 files** to **92 in 20 files**. Fixes 10 files including BunkerSilo, DensityMapParallelogram, FieldGroundSystem, WoodHarvester, and FellerBuncher.